### PR TITLE
fix(auth): prevent infinite token refresh loop on 401

### DIFF
--- a/frontend/src/components/Analytics.js
+++ b/frontend/src/components/Analytics.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { logsAPI } from '../utils/api';
 import { toast } from 'react-toastify';
 import { Activity, CheckCircle, XCircle, Clock } from 'lucide-react';
@@ -10,7 +10,7 @@ const Analytics = () => {
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     setLoading(true);
     try {
       const [statsResponse, logsResponse] = await Promise.all([
@@ -25,11 +25,11 @@ const Analytics = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [page]);
 
   useEffect(() => {
     fetchData();
-  }, [page]);
+  }, [fetchData]);
 
   if (loading) {
     return <div className="loading">Loading...</div>;

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { apisAPI } from '../utils/api';
 import { toast } from 'react-toastify';
 import { Plus, Edit2, Trash2, Eye } from 'lucide-react';
@@ -14,7 +14,7 @@ const Dashboard = () => {
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
 
-  const fetchApis = async () => {
+  const fetchApis = useCallback(async () => {
     setLoading(true);
     try {
       const response = await apisAPI.getAll(page, 10);
@@ -25,11 +25,11 @@ const Dashboard = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [page]);
 
   useEffect(() => {
     fetchApis();
-  }, [page]);
+  }, [fetchApis]);
 
   const handleCreate = () => {
     setSelectedApi(null);

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -9,6 +9,51 @@ const api = axios.create({
   },
 });
 
+// Single-flight refresh to prevent multiple 401s from triggering a refresh storm.
+let refreshPromise = null;
+
+const clearAuthAndRedirectToLogin = () => {
+  localStorage.removeItem('access_token');
+  localStorage.removeItem('refresh_token');
+  localStorage.removeItem('user');
+  // Replace (not push) so back button doesn't return to protected pages.
+  window.location.replace('/login');
+};
+
+const refreshAccessToken = async () => {
+  if (refreshPromise) return refreshPromise;
+
+  const refreshToken = localStorage.getItem('refresh_token');
+  if (!refreshToken) {
+    return Promise.reject(new Error('No refresh token available'));
+  }
+
+  refreshPromise = axios
+    .post(
+      `${API_URL}/api/auth/refresh`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${refreshToken}`,
+        },
+      }
+    )
+    .then((response) => {
+      const { access_token } = response.data;
+      localStorage.setItem('access_token', access_token);
+      return access_token;
+    })
+    .catch((err) => {
+      clearAuthAndRedirectToLogin();
+      throw err;
+    })
+    .finally(() => {
+      refreshPromise = null;
+    });
+
+  return refreshPromise;
+};
+
 api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('access_token');
@@ -27,27 +72,28 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    // If there's no config, we can't safely retry.
+    if (!originalRequest) return Promise.reject(error);
+
+    const status = error.response?.status;
+    const url = originalRequest.url || '';
+
+    // Never try to refresh for auth routes. Prevents accidental loops.
+    const isAuthRoute = url.includes('/api/auth/login') ||
+      url.includes('/api/auth/register') ||
+      url.includes('/api/auth/refresh');
+
+    if (status === 401 && !originalRequest._retry && !isAuthRoute) {
       originalRequest._retry = true;
 
       try {
-        const refreshToken = localStorage.getItem('refresh_token');
-        const response = await axios.post(`${API_URL}/api/auth/refresh`, {}, {
-          headers: {
-            Authorization: `Bearer ${refreshToken}`,
-          },
-        });
+        const accessToken = await refreshAccessToken();
 
-        const { access_token } = response.data;
-        localStorage.setItem('access_token', access_token);
-
-        originalRequest.headers.Authorization = `Bearer ${access_token}`;
+        originalRequest.headers = originalRequest.headers || {};
+        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
         return api(originalRequest);
       } catch (refreshError) {
-        localStorage.removeItem('access_token');
-        localStorage.removeItem('refresh_token');
-        localStorage.removeItem('user');
-        window.location.href = '/login';
+        // refreshAccessToken already cleared auth + redirected.
         return Promise.reject(refreshError);
       }
     }


### PR DESCRIPTION
## Summary
Fixes a bug where repeated 401 responses could trigger repeated refresh attempts and lead to an infinite loop / refresh storm.

Closes #14

## Changes
- Adds single-flight refresh logic to prevent multiple simultaneous refresh calls
- Skips refresh for auth endpoints (login/register/refresh) to avoid loops
- Clears auth state and redirects to /login when refresh fails

## How to Test
1. cd frontend
2. npm install
3. npm start
4. Login, then simulate expired/invalid token and verify:
   - refresh is attempted once
   - app redirects to /login if refresh fails
   - no infinite loop