### PR TITLE
Enhance health endpoint with database connectivity check

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -9,6 +9,8 @@ from routes.apis import apis_bp
 from routes.api_keys import api_keys_bp
 from routes.logs import logs_bp
 from routes.execute import execute_bp
+from database import check_db_connection
+
 
 app = Flask(__name__)
 app.config.from_object(Config)
@@ -40,9 +42,20 @@ def index():
         }
     }), 200
 
-@app.route('/health')
+@app.route("/health", methods=["GET"])
 def health():
-    return jsonify({'status': 'healthy'}), 200
+    db_connected = check_db_connection()
+ 
+    if db_connected:
+        return {
+            "status": "ok",
+            "database": "connected"
+        }, 200
+ 
+    return {
+        "status": "degraded",
+        "database": "disconnected"
+    }, 503
 
 @app.errorhandler(404)
 def not_found(error):

--- a/backend/database.py
+++ b/backend/database.py
@@ -17,3 +17,10 @@ def init_indexes():
     apis_collection.create_index('user_id')
     logs_collection.create_index([('timestamp', -1)])
     logs_collection.create_index('api_id')
+
+def check_db_connection():
+    try:
+        client.admin.command("ping")
+        return True
+    except PyMongoError:
+        return False


### PR DESCRIPTION
#Summary 
-Updated the /health API to also check if MongoDB is working.

#Changes
-Added a simple database check to see if MongoDB is reachable
-The /health response now shows database status
-Returns proper HTTP status codes:
-200 OK when MongoDB is running
-503 Service Unavailable when MongoDB is down

#Testing
-Started MongoDB → /health returned OK
-Stopped MongoDB → /health returned Degraded