### PR TITLE
fixes issue #1: implement rate limiting for API Endpoint protection

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,8 @@
 from flask import Flask, jsonify
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from config import Config
 from database import init_indexes
 
@@ -15,6 +17,15 @@ app.config.from_object(Config)
 
 CORS(app)
 jwt = JWTManager(app)
+
+# Initialize Rate Limiter
+limiter = Limiter(
+    app=app,
+    key_func=get_remote_address,
+    default_limits=[Config.RATELIMIT_DEFAULT],
+    storage_uri=Config.RATELIMIT_STORAGE_URL,
+    enabled=Config.RATELIMIT_ENABLED
+)
 
 app.register_blueprint(auth_bp)
 app.register_blueprint(apis_bp)
@@ -47,6 +58,10 @@ def health():
 @app.errorhandler(404)
 def not_found(error):
     return jsonify({'error': 'Resource not found'}), 404
+
+@app.errorhandler(429)
+def ratelimit_handler(e):
+    return jsonify({'error': 'Rate limit exceeded. Please try again later.', 'message': str(e.description)}), 429
 
 @app.errorhandler(500)
 def internal_error(error):

--- a/backend/config.py
+++ b/backend/config.py
@@ -12,3 +12,11 @@ class Config:
     MONGODB_URI = os.getenv('MONGODB_URI', 'mongodb://localhost:27017/api_management')
     PORT = int(os.getenv('PORT', 5000))
     FLASK_ENV = os.getenv('FLASK_ENV', 'development')
+    
+    # Rate Limiting Configuration
+    RATELIMIT_ENABLED = os.getenv('RATELIMIT_ENABLED', 'True').lower() == 'true'
+    RATELIMIT_STORAGE_URL = os.getenv('RATELIMIT_STORAGE_URL', 'memory://')
+    RATELIMIT_GLOBAL = os.getenv('RATELIMIT_GLOBAL', '10000 per hour')
+    RATELIMIT_EXECUTE_API = os.getenv('RATELIMIT_EXECUTE_API', '100 per hour')
+    RATELIMIT_AUTH = os.getenv('RATELIMIT_AUTH', '20 per hour')
+    RATELIMIT_DEFAULT = os.getenv('RATELIMIT_DEFAULT', '500 per hour')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 Flask==3.0.0
 Flask-CORS==4.0.0
 Flask-JWT-Extended==4.6.0
+Flask-Limiter==3.5.0
 pymongo==4.6.1
 python-dotenv==1.0.0
 bcrypt==4.1.2

--- a/backend/routes/execute.py
+++ b/backend/routes/execute.py
@@ -8,7 +8,11 @@ import time
 
 execute_bp = Blueprint('execute', __name__, url_prefix='/api/execute')
 
+# Import limiter from app
+from app import limiter
+
 @execute_bp.route('/<api_id>', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH'])
+@limiter.limit("100 per hour")
 @api_key_required
 def execute_api(api_id):
     try:


### PR DESCRIPTION
- Add Flask-Limiter==3.5.0 to requirements
- Configure rate limits in config.py (100/hour for API execution)
- Initialize Limiter in app.py with error handling
- Apply rate limiting decorator to execute endpoint
- Return 429 status with proper error message when limit exceeded